### PR TITLE
Get package to build on Windows 10

### DIFF
--- a/exploration_msgs/CMakeLists.txt
+++ b/exploration_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(exploration_msgs)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
 
 find_package(catkin REQUIRED COMPONENTS
   actionlib_msgs

--- a/exploration_msgs/CMakeLists.txt
+++ b/exploration_msgs/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(exploration_msgs)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
+if (MSVC)
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
+else()
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+endif()
 
 find_package(catkin REQUIRED COMPONENTS
   actionlib_msgs

--- a/exploration_server/CMakeLists.txt
+++ b/exploration_server/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 find_package(catkin REQUIRED COMPONENTS actionlib costmap_2d exploration_msgs roscpp move_base_msgs tf)
 
+# todo: need to add Boost as dependency in package.xml
 find_package(Boost REQUIRED)
 
 catkin_package(

--- a/exploration_server/CMakeLists.txt
+++ b/exploration_server/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(exploration_server)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
-
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
 
 find_package(catkin REQUIRED COMPONENTS actionlib costmap_2d exploration_msgs roscpp move_base_msgs tf)
+
+find_package(Boost REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -14,22 +15,26 @@ catkin_package(
     exploration_msgs
     roscpp
     tf
+  DEPENDS
+    Boost
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_library(exploration_server src/exploration_server.cpp)
 add_library(example_plugin src/example_plugin.cpp)
-target_link_libraries(exploration_server ${catkin_LIBRARIES})
+target_link_libraries(exploration_server ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+target_link_libraries(example_plugin ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(exploration_server_node src/exploration_server_node.cpp)
 target_link_libraries(exploration_server_node
-  exploration_server ${catkin_LIBRARIES}
+  exploration_server ${catkin_LIBRARIES} ${Boost_LIBRARIES}
 )
 
 add_executable(plugin_client src/plugin_client.cpp)
 target_link_libraries(plugin_client
-  exploration_server ${catkin_LIBRARIES}
+  exploration_server ${catkin_LIBRARIES} ${Boost_LIBRARIES}
 )
 
 install(TARGETS exploration_server exploration_server_node

--- a/exploration_server/CMakeLists.txt
+++ b/exploration_server/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(exploration_server)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
+if (MSVC)
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
+else()
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+endif()
 
 find_package(catkin REQUIRED COMPONENTS actionlib costmap_2d exploration_msgs roscpp move_base_msgs tf)
 

--- a/frontier_exploration/CMakeLists.txt
+++ b/frontier_exploration/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(frontier_exploration)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
 
 find_package(catkin REQUIRED COMPONENTS
   costmap_2d

--- a/frontier_exploration/CMakeLists.txt
+++ b/frontier_exploration/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(frontier_exploration)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
+if (MSVC)
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
+else()
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+endif()
 
 find_package(catkin REQUIRED COMPONENTS
   costmap_2d

--- a/polygon_layer/CMakeLists.txt
+++ b/polygon_layer/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(polygon_layer)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
+if (MSVC)
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
+else()
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+endif()
 
 find_package(catkin REQUIRED COMPONENTS
   costmap_2d

--- a/polygon_layer/CMakeLists.txt
+++ b/polygon_layer/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(polygon_layer)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "/std:c++14;/Wall")
 
 find_package(catkin REQUIRED COMPONENTS
   costmap_2d


### PR DESCRIPTION
Compiling with MS VS 2019 C++ compiler. There are warnings, so I had to remove the -Werror (/WX technically) parameter.

There were also issues linking Boost that I had to resolve by making all of the libraries link with boost instead of just some.